### PR TITLE
added q2 with tests

### DIFF
--- a/longest_streak.rb
+++ b/longest_streak.rb
@@ -1,0 +1,38 @@
+# longest_streak.rb
+require 'date'
+
+def longest_streak(dates)
+  return 0 if dates.empty?
+
+  sorted_dates = dates.map { |hash| Date.parse(hash[:date]) }.sort
+  longest = current = 1
+
+  sorted_dates.each_cons(2) do |prev, curr|
+    if (curr-prev).to_i == 1
+      current +=1
+      longest = current if current > longest
+    else
+      current = 1
+    end
+  end
+  longest
+end
+
+p longest_streak([{
+    date: "2019-12-30"
+  },
+  {
+    date: "2019-12-31"
+  },
+  {
+    date: "2020-01-01"
+  },
+  {
+    date: "2019-09-26"
+  },
+  {
+    date: "2019-09-27"
+  },
+  {
+    date: "2019-09-30"
+  }])

--- a/longest_streak_test.rb
+++ b/longest_streak_test.rb
@@ -1,0 +1,73 @@
+require 'minitest/autorun'
+require_relative 'longest_streak.rb'
+
+class LongestStreakTest < Minitest::Test
+  def test_basic_case
+    assert_equal 3, longest_streak([
+        {
+          date: "2019-09-18"
+        },
+        {
+          date: "2019-09-19"
+        },
+        {
+          date: "2019-09-20"
+        },
+        {
+          date: "2019-09-26"
+        },
+        {
+          date: "2019-09-27"
+        },
+        {
+          date: "2019-09-30"
+        }
+      ])
+  end
+
+  def test_end_of_month
+    assert_equal 6, longest_streak([
+        {
+            date: "2023-09-28"
+        },
+        {
+            date: "2023-09-29"
+        },
+        {
+            date: "2023-09-30"
+        },
+        {
+            date: "2023-10-01"
+        },
+        {
+            date: "2023-10-02"
+        },
+        {
+            date: "2023-10-03"
+        }
+        ])
+  end
+
+  def test_end_of_year
+    assert_equal 4, longest_streak([
+        {
+          date: "2023-12-30"
+        },
+        {
+          date: "2023-12-31"
+        },
+        {
+          date: "2024-01-01"
+        },
+        {
+          date: "2024-01-02"
+        },
+        {
+          date: "2024-09-27"
+        },
+        {
+          date: "2024-09-30"
+        }
+      ])
+  end
+end


### PR DESCRIPTION
Longest Streak

Create a function that takes an array of date hashes and return the "longest streak" (i.e. longest number of consecutive days in a row).

Notes:
An empty array should return 0.
The hashes are with symbol keys (i.e. get a date with [:date]).
Consider cases at the end of the month & end of a year.