### PR TITLE
added q8 with test

### DIFF
--- a/zip_zap.rb
+++ b/zip_zap.rb
@@ -1,0 +1,8 @@
+# zip_zap.rb
+
+def zip_zap(str)
+    str.gsub(/z.p/) {|match| match[0] + match[2]}
+  end
+  
+zip_zap('zipxzap')
+  

--- a/zip_zap_test.rb
+++ b/zip_zap_test.rb
@@ -1,0 +1,21 @@
+# zip_zap_test.rb
+require 'minitest/autorun'
+require_relative 'zip_zap'
+
+class ZipZapTest < Minitest::Test
+    def test_example_one
+      assert_equal "zpxzp", zip_zap("zipxzap")
+    end
+
+    def test_example_two
+      assert_equal "zpzp", zip_zap("zopzop")
+    end
+
+    def test_example_three
+      assert_equal "zzzpzp", zip_zap("zzzopzop")
+    end
+
+    def test_zp_with_length_of_4
+      assert_equal "ziipzaap", zip_zap("ziipzaap")
+    end
+end


### PR DESCRIPTION
zipZap

Look for patterns like "zip" and "zap" in the string -- length-3, starting with 'z' and ending with 'p'. Return a string where for all such words, the middle letter is gone, so "zipXzap" yields "zpXzp".