### PR TITLE
added q12 with tests

### DIFF
--- a/find_substring.rb
+++ b/find_substring.rb
@@ -1,0 +1,32 @@
+def find_substring(s, words)
+  return [] if s.empty? || s.length == 0 || words.empty? || words.length == 0
+
+  frequency_map = Hash.new(0)
+
+  words.each { |word| frequency_map[word] += 1 }
+
+  word_length = words[0].length
+  total_words = words.length
+  result = []
+
+  (0..s.length - total_words * word_length).each do |i|
+    seen_words = Hash.new(0)
+
+    (0...total_words).each do |j|
+      word_index = i + j * word_length
+
+      word = s[word_index, word_length]
+
+      break unless frequency_map.key?(word)
+
+      seen_words[word] += 1
+
+      break if seen_words[word] > frequency_map[word]
+
+      result.append(i) if j + 1 == total_words
+    end
+  end
+  result
+end
+
+p find_substring('dogcatcatcodecatdog', %w[cat dog])

--- a/find_substring_test.rb
+++ b/find_substring_test.rb
@@ -1,0 +1,20 @@
+require 'minitest/autorun'
+require_relative 'find_substring'
+
+class FindSubstringTest < Minitest::Test
+  def test_example_one
+    assert_equal [0, 13], find_substring('dogcatcatcodecatdog', %w[cat dog])
+  end
+
+  def test_example_two
+    assert_equal [], find_substring('barfoobazbitbyte', %w[dog cat])
+  end
+
+  def test_duplicates_of_words
+    assert_equal [3], find_substring('toptoppethockey', %w[top pet])
+  end
+
+  def test_wanted_duplicates_of_words
+    assert_equal [8, 28], find_substring('rentrentmailloadmailrentrentmailmailload', %w[mail load mail])
+  end
+end


### PR DESCRIPTION
Find Substring Indexes

Given a string s and a list of words words, where each word is the same length, find all starting indices of substrings in s that is a concatenation of every word in words exactly once.

For example, given s = "dogcatcatcodecatdog" and words = ["cat", "dog"], return [0, 13], since "dogcat" starts at index 0 and "catdog" starts at index 13.

Given s = "barfoobazbitbyte" and words = ["dog", "cat"], return [] since there are no substrings composed of "dog" and "cat" in s.

The order of the indices does not matter.