### PR TITLE
added q17 with tests

### DIFF
--- a/headline_hashtags.rb
+++ b/headline_hashtags.rb
@@ -1,0 +1,20 @@
+# The words in the input sentence are first reversed, and then the sorting is done.
+# This reversal is done to ensure that, in case of words having equal lengths,
+# the word that appeared first in the original sentence will be considered first when sorting in descending order.
+# This way, the sorting process ensures that the result retains the original order of words that have the same length.
+
+def get_hash_tags(sentence)
+  return nil if sentence.empty?
+  sentence = sentence.gsub(/[^A-Za-z\s]/, '') # removes punctiation
+  sentence.downcase!
+  return ["##{sentence}"] if sentence.split.length < 2
+
+  sentence = sentence.split.reverse
+  sorted = sentence.sort_by { |word| word.length }
+
+  sorted.reverse!
+
+  hashtags = sorted.first(3).map { |w| "##{w}" } if sorted.length > 2
+  hashtags = sorted.first(2).map { |w| "##{w}" } if sorted.length == 2
+  hashtags
+end

--- a/headline_hashtags_test.rb
+++ b/headline_hashtags_test.rb
@@ -1,0 +1,28 @@
+require 'minitest/autorun'
+require_relative 'headline_hashtags'
+
+class HeadlineHashtagsTest < Minitest::Test
+  def test_example_one
+    assert_equal ["#avocado", "#became", "#global"], get_hash_tags("How the Avocado Became the Fruit of the Global Trade")
+  end
+
+  def test_example_two
+    assert_equal ["#christmas", "#probably", "#will"], get_hash_tags("Why You Will Probably Pay More for Your Christmas Tree This Year")
+  end
+
+  def test_example_three
+    assert_equal ["#surprise", "#parents", "#fruit"], get_hash_tags("Hey Parents, Surprise, Fruit Juice Is Not Fruit")
+  end
+
+  def test_example_four
+    assert_equal ["#visualizing", "#science"], get_hash_tags("Visualizing Science")
+  end
+
+  def test_one_word
+    assert_equal ["#station"], get_hash_tags("Station")
+  end
+
+  def test_empty_string
+    assert_nil get_hash_tags("")
+  end
+end


### PR DESCRIPTION
Write a function that retrieves the top 3 longest words of a newspaper headline and transforms them into hashtags. If multiple words tie for the same length, retrieve the word that occurs first. Examples

get_hash_tags("How the Avocado Became the Fruit of the Global Trade")
➞ ["#avocado", "#became", "#global"]

get_hash_tags("Why You Will Probably Pay More for Your Christmas Tree This Year")
➞ ["#christmas", "#probably", "#will"]

get_hash_tags("Hey Parents, Surprise, Fruit Juice Is Not Fruit")
➞ ["#surprise", "#parents", "#fruit"]

get_hash_tags("Visualizing Science")
➞ ["#visualizing", "#science"]

Notes

If the title is less than 3 words, just order the words in the title by length in descending order (see example #4). Punctuation does not count towards a word's length.