### PR TITLE
added q 18 with tests

### DIFF
--- a/longest_substring_palindrome.rb
+++ b/longest_substring_palindrome.rb
@@ -1,0 +1,32 @@
+def longest_substring_palindrome(str)
+  res = ""
+  res_length = 0
+
+  (0...str.length).each do |i|
+    # odd cases
+
+    left, right = i, i
+    
+    while left >= 0 && right < str.length && str[left] == str[right]
+      if (right - left + 1) > res_length
+        res = str[left..right]
+        res_length = res.length
+      end
+      left -= 1
+      right += 1
+    end
+
+    # even cases
+    
+    left, right = i, i+1
+    while left >= 0 && right < str.length && str[left] == str[right]
+      if (right - left + 1) > res_length
+        res = str[left..right]
+        res_length = res.length
+      end
+      left -= 1
+      right += 1
+    end
+  end
+  res
+end

--- a/longest_substring_palindrome_test.rb
+++ b/longest_substring_palindrome_test.rb
@@ -1,0 +1,25 @@
+
+require 'minitest/autorun'
+require_relative 'longest_substring_palindrome'
+
+class LongestSubstringPalindrome < Minitest::Test
+  def test_example_one
+    assert_equal 'bcdcb', longest_substring_palindrome('aabcdcb')
+  end
+
+  def test_example_two
+    assert_equal 'anana', longest_substring_palindrome('bananas')
+  end
+
+  def test_length_one_palindrome
+    assert_equal 's', longest_substring_palindrome('seatbelt')
+  end
+
+  def test_more_than_one_palindrome
+    assert_equal 'malayalam', longest_substring_palindrome('malayalamracecar')
+  end
+
+  def test_empty_string
+    assert_equal '', longest_substring_palindrome('')
+  end
+end


### PR DESCRIPTION
This problem was asked by Amazon.

Given a string, find the longest palindromic contiguous substring. If there are more than one with the maximum length, return any one.

For example, the longest palindromic substring of "aabcdcb" is "bcdcb". The longest palindromic substring of "bananas" is "anana".